### PR TITLE
Follow symlinks in find command

### DIFF
--- a/src/collect-csv
+++ b/src/collect-csv
@@ -40,47 +40,47 @@ files="manufacturer \
 TEMP=$(getopt --name collect-csv --options o: --longoptions output: -- "$@")
 eval set -- "$TEMP"
 while true; do
-        case "$1" in
-            -o|--output)
-		logfile="$2"; shift 2; continue
-                ;;
-	    --) # no more arguments to parse
-		break
-		;;
-            *)
-                printf "Unknown option %s\n" "$1"
-                exit 1
-                ;;
-	esac
+    case "$1" in
+        -o|--output)
+            logfile="$2"; shift 2; continue
+            ;;
+        --) # no more arguments to parse
+            break
+            ;;
+        *)
+            printf "Unknown option %s\n" "$1"
+            exit 1
+            ;;
+    esac
 done
 
 if [ ! -e "$logfile" ] ; then
     (
-	printf "timestamp,when,"
-	for f in $files; do
-	    printf "%s," $f
-	done
-	echo
+        printf "timestamp,when,"
+        for f in $files; do
+            printf "%s," $f
+        done
+        echo
     ) > "$logfile"
 fi
 
 log_battery() {
     printf "%s,%s," "$(date +%s)" "$(date --iso-8601=seconds)"
-    for f in $files; do 
-	for file in $(echo $f | tr / " "); do
-	    if [ -e $file ] ; then fexist=$file; else fexist= ; fi
-	done
-	if [ "$fexist" ] && [ -e "$fexist" ] ; then
-	    printf "%s," "$(cat $fexist | sed -s 's/\(.* .*\)/"\1"/' )"
-	else
-	    printf ","
-	fi
+    for f in $files; do
+        for file in $(echo $f | tr / " "); do
+            if [ -e $file ] ; then fexist=$file; else fexist= ; fi
+        done
+        if [ "$fexist" ] && [ -e "$fexist" ] ; then
+            printf "%s," "$(cat $fexist | sed -s 's/\(.* .*\)/"\1"/' )"
+        else
+            printf ","
+        fi
     done
 }
 
 cd /sys/class/power_supply
 
-for bat in $(find . -maxdepth 1 -name "BAT*" -type d); do
+for bat in $(find -L . -maxdepth 1 -name "BAT*" -type d); do
     # Print complete message in one echo call, to avoid race condition
     # when several log processes run in parallel.
     (cd $bat && echo $(log_battery)) >> "$logfile"


### PR DESCRIPTION
Add -L option to find command. If BAT\* are symlinks (like it is the case in my laptop) the find command returns no directories.

Also fixed some broken indentation.
