### PR TITLE
handle polyfit exceptions

### DIFF
--- a/src/battery-stats-graph
+++ b/src/battery-stats-graph
@@ -221,9 +221,12 @@ if __name__ == "__main__":
     # we compute the mean design capacity, then take the given percentage out of that
     logging.debug('guessing expiry')
     zero = args.death * np.mean(data[full_design]) / 100
-    death = guess_expiry(data[full], data['timestamp'], zero)
-    logging.info("this battery will reach end of life (%s%%) in %s, on %s",
-                 args.death, death - datetime.datetime.now(), death)
+    try:
+        death = guess_expiry(data[full], data['timestamp'], zero)
+        logging.info("this battery will reach end of life (%s%%) in %s, on %s",
+                     args.death, death - datetime.datetime.now(), death)
+    except ValueError as e:
+        logging.warning("could not guess battery expiry: %s", e)
 
     build_graph(data)
     render_graph()


### PR DESCRIPTION
in some weird cases (e.g. my battery changed, actually), the polyfit
function will freak out and give a ValueError exception:

    Traceback (most recent call last):
      File "./src/battery-stats-graph", line 199, in <module>
        death = guess_expiry(data[full], data['timestamp'], zero)
      File "./src/battery-stats-graph", line 170, in guess_expiry
        fit = np.polyfit(data[full], data['timestamp'], 1)
      File "/usr/lib/python2.7/dist-packages/numpy/lib/polynomial.py", line 581, in polyfit
        c, resids, rank, s = lstsq(lhs, rhs, rcond)
      File "/usr/lib/python2.7/dist-packages/numpy/linalg/linalg.py", line 1867, in lstsq
        0, work, lwork, iwork, 0)
    ValueError: On entry to DLASCL parameter number 4 had an illegal value

we shouldn't completely crash in those cases: if we fail to find a fit
or the data is too much garbage, just output a warning and attempt to
generate the graph anyways