### PR TITLE
handle null values in logfiles

### DIFF
--- a/src/battery-stats-graph
+++ b/src/battery-stats-graph
@@ -50,6 +50,21 @@ now = 'energy_now'
 full = 'energy_full'
 full_design = 'energy_full_design'
 
+# keep a copy of the original iterator function
+real_readline = logfiles.next
+
+def sanitized_readline():
+    """clear out null characters from input
+
+Those show up in the CSV logfiles frequently as updates happen during
+shutdown or power outages.
+    """
+    line = real_readline()
+    return line.replace("\0", "")
+
+# replace the iterator with our filtered version
+logfiles.next = sanitized_readline
+
 def parse_csv_np():
     logging.debug('loading CSV file %s with NumPy', args.logfile)
     data = np.genfromtxt(logfiles,


### PR DESCRIPTION
In my experience, the CSV logfile frequently gets garbage written to
it. It's unclear to me why that happens: presumably the update script
does that when there's a power outage or suspend or something weird
that frequently happens on laptops.

Instead of trying to figure out how the impossible happens, I figured
it might be better to just deal with it better and silence those
errors. I tried to do this in a better way by using an open hook, but
it's actually quite difficult to do so because compressed handles
don't support customizing the encoding routines the same way io.open
does. Instead we monkeypatch the iterator eventually used by the CSV
parser, which works in my tests.