### PR TITLE
Add ADP0 power supply (Dell XPS13 2012)

### DIFF
--- a/src/battery-stats-collector
+++ b/src/battery-stats-collector
@@ -28,6 +28,8 @@ get_logline() {
         aconline=$(cat /sys/class/power_supply/AC0/online)
     elif [ -f /sys/class/power_supply/ACAD/online ]; then
         aconline=$(cat /sys/class/power_supply/ACAD/online)
+    elif [ -f /sys/class/power_supply/ADP0/online ]; then
+        aconline=$(cat /sys/class/power_supply/ADP0/online)
     elif [ -f /sys/class/power_supply/ADP1/online ]; then
         aconline=$(cat /sys/class/power_supply/ADP1/online)
     else


### PR DESCRIPTION
ADP0 is not check for online status, resulting in "No power supply found" in log and no graph shown by battery-graph.