### PR TITLE
collector: sync only the logfile

### DIFF
--- a/src/battery-stats-collector
+++ b/src/battery-stats-collector
@@ -138,7 +138,7 @@ while true; do
 
     # Do a filesystem sync to increase the chance of the log line
     # actually making it to disk.
-    sync
+    sync $logfile
 
     if [ 0 -lt $sample_interval_secs ] ; then
         sleep $sample_interval_secs


### PR DESCRIPTION
When logging battery stats, sync only the logfile, not the whole filesystem.

This prevents `sync` from hanging or causing unneccesary file IO when there are long-running operations happening on the rootfs. It will also reduce battery drain.