### PR TITLE
Fix for gnuplot title option

### DIFF
--- a/src/battery-graph.in
+++ b/src/battery-graph.in
@@ -211,6 +211,8 @@ ZERO_BIOS_ESTIMATE=`tail -n 1 $TMPFILENAME | awk '{ print $6 }'`
 	echo "g(x) = x<zero_time?(x>full_time?f(x):1/0):1/0"
     fi
 
+    echo "set term wxt title \"$title\""
+
     echo "set xrange [ $from2000 : $to2000 ] noreverse"
 	echo plot "\"$TMPFILENAME\" using (\$1 - $adjustment):(\$3==2?\$2:1/0) smooth unique axis x1y1 title \"Plugged in\" with lines linecolor rgb \"blue\" linewidth 3, \
 	\"\" using (\$1 - $adjustment):(\$3==1?\$2:1/0) smooth unique axis x1y1 title \"Discharging\" with lines linecolor rgb \"red\" linewidth 3, \
@@ -219,7 +221,7 @@ ZERO_BIOS_ESTIMATE=`tail -n 1 $TMPFILENAME | awk '{ print $6 }'`
 		echo ", g(x -($TIME_LAST_DISCHARGE_BEGIN-$adjustment) ) title (B<0?sprintf(\"slope= (%.2f +/- %.2f) %/h\", B*3600, B_err*3600):\"\") lc rgb \"black\" lt 2 "
     fi
     
-)  | gnuplot -persist ${geometry:+-geometry} $geometry ${title:+-title} "${title}" ; rm -f $TMPFILENAME
+)  | gnuplot -persist ${geometry:+-geometry} $geometry ; rm -f $TMPFILENAME
 
 
 # TODO Have to decide if we want to clean up or leave the file for us to zoom in/out in the graph


### PR DESCRIPTION
At some point, gnuplot stopped accepting a -title option on the command line; this is the case at least as of of gnuplot 6.0 patchlevel 4.  It is still possible to set a window title via use of the "set term wxt title" directive.  Use this directive instead.

Without this patch, battery-graph will not display anything.